### PR TITLE
Version 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `ILRepackRenameEnabled` property to rename the output file to change the assembly name with revision.
 ### Updates
 - Update `ILRepackVersion` with condition.
+- Update to show `TargetFramework` in the console.
 ### Sample
 - Ignore `System.Text.Encodings.Web` issue in repack.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update `ILRepackVersion` with condition.
 - Update to show `TargetFramework` in the console.
 ### Sample
-- Ignore `System.Text.Encodings.Web` issue in repack.
+- Only include `System.Text.Json` in net framework, issue with repack and net core.
 
 ## [1.0.0] / 2024-09-03 - 2025-01-30
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] / 2025-02-03
+### Updates
+- Update `ILRepackVersion` with condition.
+
 ## [1.0.0] / 2024-09-03 - 2025-01-30
 ### Features
 - Support `ILRepack` version `2.0.36`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.0.1] / 2025-02-03
+### Experimental Features
+- `ILRepackRenameEnabled` property to rename the output file to change the assembly name with revision.
 ### Updates
 - Update `ILRepackVersion` with condition.
 
@@ -22,4 +24,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update `ILRepackIgnoreReferences` to ignore all files starts with include name.
 
 [vNext]: ../../compare/1.0.0...HEAD
+[1.0.1]: ../../compare/1.0.0...1.0.1
 [1.0.0]: ../../compare/1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.0.1] / 2025-02-03
+### Features
+- Update `ILRepack` version `2.0.38`.
 ### Experimental Features
 - `ILRepackRenameEnabled` property to rename the output file to change the assembly name with revision.
 ### Updates
 - Update `ILRepackVersion` with condition.
+### Sample
+- Ignore `System.Text.Encodings.Web` issue in repack.
 
 ## [1.0.0] / 2024-09-03 - 2025-01-30
 ### Features

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>1.0.1-rc</Version>
+    <Version>1.0.1</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.0.1-alpha</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>1.0.1-beta</Version>
+    <Version>1.0.1-beta.1</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>1.0.1-alpha.1</Version>
+    <Version>1.0.1-beta</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>1.0.1-alpha</Version>
+    <Version>1.0.1-alpha.1</Version>
 	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-    <Version>1.0.1-beta.1</Version>
+    <Version>1.0.1-rc</Version>
 	</PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build](https://github.com/ricaun-io/ricaun.ILRepack/actions/workflows/Build.yml/badge.svg)](https://github.com/ricaun-io/ricaun.ILRepack/actions)
 [![Release](https://img.shields.io/nuget/v/ricaun.ILRepack?logo=nuget&label=release&color=blue)](https://www.nuget.org/packages/ricaun.ILRepack)
 
-`ricaun.ILRepack` is a basic repack for .NET assemblies. Uses the package [ILRepack](https://github.com/gluck/il-repack) version `2.0.36` to repack the assembly using `Target` to replace the original assembly to the repack assembly with all the dependencies included.
+`ricaun.ILRepack` is a basic repack for .NET assemblies. Uses the package [ILRepack](https://github.com/gluck/il-repack) version `2.0.38` to repack the assembly using `Target` to replace the original assembly to the repack assembly with all the dependencies included.
 
 ## Installation
 

--- a/ricaun.ILRepack.Sample.Tests/Tests.cs
+++ b/ricaun.ILRepack.Sample.Tests/Tests.cs
@@ -19,7 +19,7 @@ namespace ricaun.ILRepack.Sample.Tests
             Console.WriteLine(c.ToJson());
             Assert.AreEqual(c.ToString(), c.ToJson());
         }
-
+#if NETFRAMEWORK
         [Test]
         public void TestReferenceName_AreEqual()
         {
@@ -27,7 +27,7 @@ namespace ricaun.ILRepack.Sample.Tests
             Console.WriteLine(References.System_Text_Json);
             Assert.AreEqual(name, References.System_Text_Json);
         }
-
+#endif
         [Test]
         public void TestReferenceName_AreNotEqual()
         {

--- a/ricaun.ILRepack.Sample/ricaun.ILRepack.Sample.csproj
+++ b/ricaun.ILRepack.Sample/ricaun.ILRepack.Sample.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ILRepackIgnoreReferences Include="Newtonsoft.Json" />
+    <ILRepackIgnoreReferences Include="Newtonsoft.Json;System.Text.Encodings.Web" />
   </ItemGroup>
   
   <PropertyGroup>

--- a/ricaun.ILRepack.Sample/ricaun.ILRepack.Sample.csproj
+++ b/ricaun.ILRepack.Sample/ricaun.ILRepack.Sample.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="ricaun.ILRepack" Version="*-*" Condition="!$(Configuration.Contains('Debug'))" />
-    <PackageReference Include="System.Text.Json" Version="*" PrivateAssets="All" />
+    <PackageReference Include="System.Text.Json" Version="8.*" PrivateAssets="All" Condition="$(TargetFramework.StartsWith('net4'))" />
     <PackageReference Include="Newtonsoft.Json" Version="*" />
   </ItemGroup>
 
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ILRepackIgnoreReferences Include="Newtonsoft.Json;System.Text.Encodings.Web" />
+    <ILRepackIgnoreReferences Include="Newtonsoft.Json" />
   </ItemGroup>
   
   <PropertyGroup>

--- a/ricaun.ILRepack/ricaun.ILRepack.csproj
+++ b/ricaun.ILRepack/ricaun.ILRepack.csproj
@@ -98,7 +98,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ILRepack" Version="2.0.36" />
+    <PackageReference Include="ILRepack" Version="2.0.38" />
   </ItemGroup>
 
   <Target Name="CopyPackFiles" AfterTargets="Pack" Condition="!$(Configuration.Contains('Debug'))">

--- a/ricaun.ILRepack/ricaun.ILRepack.targets
+++ b/ricaun.ILRepack/ricaun.ILRepack.targets
@@ -9,6 +9,7 @@
     <ILRepackEnabled Condition="'$(ILRepackEnabled)' == ''">true</ILRepackEnabled>
     <ILRepackDeleteEnabled Condition="'$(ILRepackDeleteEnabled)' == ''">true</ILRepackDeleteEnabled>
     <ILRepackImportance Condition="'$(ILRepackImportance)' == ''">Low</ILRepackImportance>
+    <ILRepackRenameEnabled Condition="'$(ILRepackRenameEnabled)' == ''">false</ILRepackRenameEnabled>
   </PropertyGroup>
 
   <Target Name="ILRepackTarget" BeforeTargets="CopyFilesToOutputDirectory" Condition="$(ILRepackEnabled)">
@@ -17,6 +18,15 @@
       <ILRepackFileName>$(TargetName)$(TargetExt)</ILRepackFileName>
       <ILRepackProgramAssembly>@(IntermediateAssembly->'%(FullPath)')</ILRepackProgramAssembly>
       <ILRepackOutputFile>$(ILRepackProgramAssembly)</ILRepackOutputFile>
+      <ILRepackOutputFileName>$(ILRepackFileName)</ILRepackOutputFileName>
+      <ILRepackOutputRenameFile>$(ILRepackOutputFile)</ILRepackOutputRenameFile>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="$(ILRepackRenameEnabled)">
+      <ILRepackProgramFolder>@(IntermediateAssembly->'%(RelativeDir)')</ILRepackProgramFolder>
+      <ILRepackOutputFileRevision>$([MSBuild]::Divide($([System.DateTime]::Now.TimeOfDay.TotalSeconds), 4).ToString('F0'))</ILRepackOutputFileRevision>
+      <ILRepackOutputFileName>$(TargetName).$(ILRepackOutputFileRevision)$(TargetExt)</ILRepackOutputFileName>
+      <ILRepackOutputRenameFile>$(ILRepackProgramFolder)$(ILRepackOutputFileName)</ILRepackOutputRenameFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -36,6 +46,10 @@
       <ILRepackIncludedEmbeddedAssemblies
         Include="@(ILRepackIncludedAssemblyReferences)"
         Exclude="@(ILRepackExcludedEmbeddedAssemblies)" />
+      
+      <!-- Remove All Assemblies References -->
+      <ILRepackIncludedEmbeddedAssemblies Remove="@(ILRepackIncludedEmbeddedAssemblies)" Condition="$(ILRepackRenameEnabled)" />
+      
       <ILRepackInputAssemblies Include="$(ILRepackProgramAssembly)" />
       <ILRepackInputAssemblies Include="@(ILRepackIncludedEmbeddedAssemblies)" />
     </ItemGroup>
@@ -55,13 +69,13 @@
     <PropertyGroup>
       <ILRepackCommandExtra Condition="'$(ILRepackCommandExtra)' == ''"></ILRepackCommandExtra>
       <ILRepackCommandImportance Condition="'$(ILRepackCommandImportance)' == ''">Low</ILRepackCommandImportance>
-      <ILRepackCommandOutput>/out:&quot;$(ILRepackOutputFile)&quot;</ILRepackCommandOutput>
+      <ILRepackCommandOutput>/out:&quot;$(ILRepackOutputRenameFile)&quot;</ILRepackCommandOutput>
       <ILRepackCommandInputAssemblies>@(ILRepackInputAssemblies -> '&quot;%(identity)&quot;', ' ')</ILRepackCommandInputAssemblies>
       <!-- Space in the end is used to mitigate slash with quot error.-->
       <ILRepackCommandLibFolder>@(BuildReferenceFolderDistinctSlash -> '/lib:&quot;%(identity) &quot;', ' ')</ILRepackCommandLibFolder>
     </PropertyGroup>
 
-    <Message Text="ILRepack: $(ILRepackFileName) [@(ILRepackInputAssemblies -> '%(Filename)%(Extension)', ', ')]" Importance="$(ILRepackImportance)" />
+    <Message Text="ILRepack: $(ILRepackOutputFileName) [@(ILRepackInputAssemblies -> '%(Filename)%(Extension)', ', ')]" Importance="$(ILRepackImportance)" />
 
     <PropertyGroup>
       <ILRepackFullCommand>&quot;$(ILRepack)&quot; $(ILRepackCommandExtra) $(ILRepackCommandLibFolder) $(ILRepackCommandOutput) $(ILRepackCommandInputAssemblies)</ILRepackFullCommand>
@@ -75,6 +89,8 @@
           ConsoleToMSBuild="true"
           StandardOutputImportance="$(ILRepackCommandImportance)"/>
 
+    <Move SourceFiles="$(ILRepackOutputRenameFile)" DestinationFiles="$(ILRepackOutputFile)" Condition="$(ILRepackRenameEnabled)"/>
+
   </Target>
 
   <Target Name="ILRepackDeleteTarget" AfterTargets="ILRepackTarget" Condition="$(ILRepackEnabled) and $(ILRepackDeleteEnabled)">
@@ -87,7 +103,7 @@
         <Files>$([System.IO.Directory]::GetFiles("%(Directories.Identity)", "*", System.IO.SearchOption.AllDirectories).get_Length())</Files>
       </Directories>
     </ItemGroup>
-    <RemoveDir Directories="@(Directories)" Condition="%(Files)=='0'"/>
+    <RemoveDir Directories="@(Directories)" Condition="%(Files)=='0'"/>    
   </Target>
 
 </Project>

--- a/ricaun.ILRepack/ricaun.ILRepack.targets
+++ b/ricaun.ILRepack/ricaun.ILRepack.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <ILRepackVersion>2.0.36</ILRepackVersion>
+    <ILRepackVersion Condition="'$(ILRepackVersion)' == ''">2.0.36</ILRepackVersion>
     <ILRepack Condition="'$(ILRepack)' == ''">$(NuGetPackageRoot)ilrepack\$(ILRepackVersion)\tools\ILRepack.exe</ILRepack>
   </PropertyGroup>
 

--- a/ricaun.ILRepack/ricaun.ILRepack.targets
+++ b/ricaun.ILRepack/ricaun.ILRepack.targets
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <ILRepackVersion Condition="'$(ILRepackVersion)' == ''">2.0.36</ILRepackVersion>
+    <ILRepackVersion Condition="'$(ILRepackVersion)' == ''">2.0.38</ILRepackVersion>
     <ILRepack Condition="'$(ILRepack)' == ''">$(NuGetPackageRoot)ilrepack\$(ILRepackVersion)\tools\ILRepack.exe</ILRepack>
   </PropertyGroup>
 

--- a/ricaun.ILRepack/ricaun.ILRepack.targets
+++ b/ricaun.ILRepack/ricaun.ILRepack.targets
@@ -94,7 +94,7 @@
   </Target>
 
   <Target Name="ILRepackDeleteTarget" AfterTargets="ILRepackTarget" Condition="$(ILRepackEnabled) and $(ILRepackDeleteEnabled)">
-    <Message Text="ILRepack Delete: [@(ILRepackIncludedEmbeddedAssemblies -> '%(Filename)%(Extension)', ', ')]" Importance="$(ILRepackImportance)" />
+    <Message Text="ILRepack Delete: [@(ILRepackIncludedEmbeddedAssemblies -> '%(Filename)%(Extension)', ', ')]" Importance="$(ILRepackImportance)" Condition="'@(ILRepackIncludedEmbeddedAssemblies->Count())' != '0'" />
 
     <Delete Files="@(ILRepackIncludedEmbeddedAssemblies)" />
     <ItemGroup>

--- a/ricaun.ILRepack/ricaun.ILRepack.targets
+++ b/ricaun.ILRepack/ricaun.ILRepack.targets
@@ -75,7 +75,7 @@
       <ILRepackCommandLibFolder>@(BuildReferenceFolderDistinctSlash -> '/lib:&quot;%(identity) &quot;', ' ')</ILRepackCommandLibFolder>
     </PropertyGroup>
 
-    <Message Text="ILRepack: $(ILRepackOutputFileName) [@(ILRepackInputAssemblies -> '%(Filename)%(Extension)', ', ')]" Importance="$(ILRepackImportance)" />
+    <Message Text="ILRepack: $(ILRepackOutputFileName) [@(ILRepackInputAssemblies -> '%(Filename)%(Extension)', ', ')] ($(TargetFramework))" Importance="$(ILRepackImportance)" />
 
     <PropertyGroup>
       <ILRepackFullCommand>&quot;$(ILRepack)&quot; $(ILRepackCommandExtra) $(ILRepackCommandLibFolder) $(ILRepackCommandOutput) $(ILRepackCommandInputAssemblies)</ILRepackFullCommand>


### PR DESCRIPTION
### Features
- Update `ILRepack` version `2.0.38`.
### Experimental Features
- `ILRepackRenameEnabled` property to rename the output file to change the assembly name with revision.
### Updates
- Update `ILRepackVersion` with condition.
- Update to show `TargetFramework` in the console.
### Sample
- Only include `System.Text.Json` in net framework, issue with repack and net core.